### PR TITLE
dcraw_common.cpp: Use signed char to fix compilation with gcc 6 and A…

### DIFF
--- a/Source/LibRawLite/internal/dcraw_common.cpp
+++ b/Source/LibRawLite/internal/dcraw_common.cpp
@@ -2479,7 +2479,7 @@ void CLASS quicktake_100_load_raw()
 
 void CLASS kodak_radc_load_raw()
 {
-  static const char src[] = {
+  static const signed char src[] = {
     1,1, 2,3, 3,4, 4,2, 5,7, 6,5, 7,6, 7,8,
     1,0, 2,1, 3,3, 4,4, 5,2, 6,7, 7,6, 8,5, 8,8,
     2,1, 2,3, 3,0, 3,2, 3,4, 4,6, 5,5, 6,7, 6,8,


### PR DESCRIPTION
…RM targets

As per suggestion from https://bugzilla.redhat.com/show_bug.cgi?id=1307280

Signed-off-by: Herman van Hazendonk github.com@herrie.org
